### PR TITLE
target k8s >= 1.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,23 +1292,22 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
+checksum = "aa60a41b57ae1a0a071af77dbcf89fc9819cfe66edaf2beeb204c34459dcf0b2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "schemars",
  "serde",
- "serde-value",
  "serde_json",
 ]
 
 [[package]]
 name = "kube"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4eb20010536b48abe97fec37d23d43069bcbe9686adcf9932202327bc5ca6e"
+checksum = "1b49c39074089233c2bb7b1791d1b6c06c84dbab26757491fad9d233db0d432f"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1299,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc2ed952042df20d15ac2fe9614d0ec14b6118eab89633985d4b36e688dccf1"
+checksum = "e199797b1b08865041c9c698f0d11a91de0a8143e808b71e250cd4a1d7ce2b9f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1336,11 +1355,12 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0d0793db58e70ca6d689489183816cb3aa481673e7433dc618cf7e8007c675"
+checksum = "1bdefbba89dea2d99ea822a1d7cd6945535efbfb10b790056ee9284bf9e698e7"
 dependencies = [
  "chrono",
+ "derive_more",
  "form_urlencoded",
  "http",
  "json-patch",
@@ -1354,9 +1374,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c562f58dc9f7ca5feac8a6ee5850ca221edd6f04ce0dd2ee873202a88cd494c9"
+checksum = "8e609a3633689a50869352a3c16e01d863b6137863c80eeb038383d5ab9f83bf"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1368,14 +1388,13 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.99.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f34cfab9b4bd8633062e0e85edb81df23cb09f159f2e31c60b069ae826ffdc"
+checksum = "1d4bd8a4554786f8f9a87bfa977fb7dbaa1d7f102a30477338b044b65de29d8e"
 dependencies = [
  "ahash",
  "async-broadcast",
  "async-stream",
- "async-trait",
  "backon",
  "educe",
  "futures",
@@ -1757,7 +1776,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ You can also have the controller query all solvers and return the combined set o
 
 To install this operator, use the Helm chart at [spacebird-dev/charts](https://github.com/spacebird-dev/charts/tree/main/charts/externalip-manager).
 
+To see the minimum supported k8s version, check the `k8s-openapi` feature flag in [crates/bin/Cargo.toml](./crates/bin/Cargo.toml)
+
 ## Building
 
 This operator is built in Rust, using standard `cargo` tooling.

--- a/crates/bin/Cargo.toml
+++ b/crates/bin/Cargo.toml
@@ -8,7 +8,7 @@ description = "Manage ExternalIP assignments on Kubernetes Services"
 anyhow = "1.0.95"
 clap = { version = "4.5.28", features = ["derive", "env", "string"] }
 tokio = { version = "1.43.0", features = ["full"] }
-k8s-openapi = { version = "0.24.0", features = ["schemars", "v1_28"] }
+k8s-openapi = { version = "0.25.0", features = ["schemars", "v1_30"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 tracing = "0.1.41"
 externalip-manager-manager = { path = "../manager" }

--- a/crates/crd-exporter/Cargo.toml
+++ b/crates/crd-exporter/Cargo.toml
@@ -8,7 +8,7 @@ description = "Utility crate to generate YAMLs for externalip-managers CRDs"
 clap = { version = "4.5.28", features = ["derive"] }
 externalip-manager-manager = { path = "../manager" }
 serde_yaml = "0.9.34"
-kube = { version = "0.99.0", features = ["runtime", "derive"] }
+kube = { version = "1.0.0", features = ["runtime", "derive"] }
 # Not actually used, just needed to get k8s_openapi to compile
-k8s-openapi = { version = "0.24.0", features = ["schemars", "v1_28"] }
+k8s-openapi = { version = "0.25.0", features = ["schemars", "v1_30"] }
 anyhow = "1.0.95"

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -15,8 +15,8 @@ reqwest = { version = "0.12.12", default-features = false, features = [
 async-trait = "0.1.86"
 hickory-resolver = "0.25.0"
 itertools = "0.14.0"
-k8s-openapi = { version = "0.24.0", features = ["schemars"] }
-kube = { version = "0.99.0", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.25.0", features = ["schemars"] }
+kube = { version = "1.0.0", features = ["runtime", "derive"] }
 schemars = "0.8.21"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
@@ -26,4 +26,4 @@ tracing = "0.1.41"
 
 [dev-dependencies]
 # we do enable a specific version for dev, so that tests can run
-k8s-openapi = { version = "0.24.0", features = ["schemars", "v1_28"] }
+k8s-openapi = { version = "0.25.0", features = ["schemars", "v1_30"] }


### PR DESCRIPTION
The newest k8s-openapi version only supported k8s 1.30 or newer, bump versions accordingly. Since our operator is pretty simple it *should* still work on older versions, but there is no guaranee for that.